### PR TITLE
Implement listen URL builder

### DIFF
--- a/Jellyfin.Plugin.Template.Tests/ListenUrlBuilderTests.cs
+++ b/Jellyfin.Plugin.Template.Tests/ListenUrlBuilderTests.cs
@@ -1,0 +1,32 @@
+using System;
+using Jellyfin.Plugin.Template;
+using MediaBrowser.Controller.Entities.Audio;
+using MediaBrowser.Controller.Entities;
+using Xunit;
+
+namespace Jellyfin.Plugin.Template.Tests;
+
+public class ListenUrlBuilderTests
+{
+    [Fact]
+    public void AudioItems_ReturnListenUrl()
+    {
+        var item = new Audio { Id = Guid.NewGuid() };
+        var builder = new ListenUrlBuilder();
+
+        var url = builder.GetUrl(item);
+
+        Assert.Equal($"/listen/{item.Id}", url);
+    }
+
+    [Fact]
+    public void VideoItems_ReturnDownloadUrl()
+    {
+        var item = new Video { Id = Guid.NewGuid() };
+        var builder = new ListenUrlBuilder();
+
+        var url = builder.GetUrl(item);
+
+        Assert.Equal($"/Items/{item.Id}/Download", url);
+    }
+}

--- a/Jellyfin.Plugin.Template/IDownloadUrlBuilder.cs
+++ b/Jellyfin.Plugin.Template/IDownloadUrlBuilder.cs
@@ -1,0 +1,16 @@
+using MediaBrowser.Controller.Entities;
+
+namespace Jellyfin.Plugin.Template;
+
+/// <summary>
+/// Service that builds download URLs for items.
+/// </summary>
+public interface IDownloadUrlBuilder
+{
+    /// <summary>
+    /// Gets the download URL for an item.
+    /// </summary>
+    /// <param name="item">The library item.</param>
+    /// <returns>The download URL.</returns>
+    string GetUrl(BaseItem item);
+}

--- a/Jellyfin.Plugin.Template/ListenController.cs
+++ b/Jellyfin.Plugin.Template/ListenController.cs
@@ -1,0 +1,23 @@
+using System;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Jellyfin.Plugin.Template;
+
+/// <summary>
+/// Redirects listen URLs to the standard Jellyfin download endpoint.
+/// </summary>
+[ApiController]
+[Route("listen")]
+public sealed class ListenController : ControllerBase
+{
+    /// <summary>
+    /// Redirects /listen/{id} to the built-in download route.
+    /// </summary>
+    /// <param name="id">Item identifier.</param>
+    /// <returns>A redirect result.</returns>
+    [HttpGet("{id}")]
+    public IActionResult Listen(Guid id)
+    {
+        return Redirect($"/Items/{id}/Download");
+    }
+}

--- a/Jellyfin.Plugin.Template/ListenUrlBuilder.cs
+++ b/Jellyfin.Plugin.Template/ListenUrlBuilder.cs
@@ -1,0 +1,23 @@
+using System;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Audio;
+
+namespace Jellyfin.Plugin.Template;
+
+/// <summary>
+/// Implementation of <see cref="IDownloadUrlBuilder"/> that returns a custom
+/// URL for audio items.
+/// </summary>
+public sealed class ListenUrlBuilder : IDownloadUrlBuilder
+{
+    /// <inheritdoc />
+    public string GetUrl(BaseItem item)
+    {
+        if (item is Audio)
+        {
+            return $"/listen/{item.Id}";
+        }
+
+        return $"/Items/{item.Id}/Download";
+    }
+}

--- a/Jellyfin.Plugin.Template/ServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Template/ServiceRegistrator.cs
@@ -1,0 +1,17 @@
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Plugins;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Jellyfin.Plugin.Template;
+
+/// <summary>
+/// Registers plugin services with the Jellyfin server.
+/// </summary>
+public sealed class ServiceRegistrator : IPluginServiceRegistrator
+{
+    /// <inheritdoc />
+    public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
+    {
+        serviceCollection.AddSingleton<IDownloadUrlBuilder, ListenUrlBuilder>();
+    }
+}


### PR DESCRIPTION
## Summary
- implement `ListenController` redirecting `/listen/{id}` to the download route
- add `IDownloadUrlBuilder` interface and `ListenUrlBuilder` class
- register the service through `ServiceRegistrator`
- test that audio items use `/listen/{id}` while video uses `/items/{id}/download`

## Testing
- `dotnet build --configuration Release --no-restore`
- `dotnet test --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_684a821bc8c883208c65899ddc94f91e