### PR TITLE
Update plugin metadata and build

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,5 @@
     "jellyfinWindowsDataDir": "${env:LOCALAPPDATA}/jellyfin",
     "jellyfinLinuxDataDir": "$HOME/.local/share/jellyfin",
     // The name of the plugin
-    "pluginName": "Jellyfin.Plugin.Template",
+    "pluginName": "Jellyfin.Plugin.ListenUrl",
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
-        <Version>0.0.0.0</Version>
-        <AssemblyVersion>0.0.0.0</AssemblyVersion>
-        <FileVersion>0.0.0.0</FileVersion>
+        <Version>0.1.0.0</Version>
+        <AssemblyVersion>0.1.0.0</AssemblyVersion>
+        <FileVersion>0.1.0.0</FileVersion>
     </PropertyGroup>
 </Project>

--- a/Jellyfin.Plugin.Template.Tests/ListenUrlBuilderTests.cs
+++ b/Jellyfin.Plugin.Template.Tests/ListenUrlBuilderTests.cs
@@ -1,10 +1,10 @@
 using System;
-using Jellyfin.Plugin.Template;
+using Jellyfin.Plugin.ListenUrl;
 using MediaBrowser.Controller.Entities.Audio;
 using MediaBrowser.Controller.Entities;
 using Xunit;
 
-namespace Jellyfin.Plugin.Template.Tests;
+namespace Jellyfin.Plugin.ListenUrl.Tests;
 
 public class ListenUrlBuilderTests
 {

--- a/Jellyfin.Plugin.Template.Tests/PluginTests.cs
+++ b/Jellyfin.Plugin.Template.Tests/PluginTests.cs
@@ -1,11 +1,11 @@
 using System;
 using System.IO;
-using Jellyfin.Plugin.Template;
+using Jellyfin.Plugin.ListenUrl;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Model.Serialization;
 using Xunit;
 
-namespace Jellyfin.Plugin.Template.Tests;
+namespace Jellyfin.Plugin.ListenUrl.Tests;
 
 public class PluginTests
 {

--- a/Jellyfin.Plugin.Template/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.Template/Configuration/PluginConfiguration.cs
@@ -1,6 +1,6 @@
 using MediaBrowser.Model.Plugins;
 
-namespace Jellyfin.Plugin.Template.Configuration;
+namespace Jellyfin.Plugin.ListenUrl.Configuration;
 
 /// <summary>
 /// The configuration options.

--- a/Jellyfin.Plugin.Template/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Template/Configuration/configPage.html
@@ -2,13 +2,13 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>Template</title>
+    <title>Listen URL</title>
 </head>
 <body>
-    <div id="TemplateConfigPage" data-role="page" class="page type-interior pluginConfigurationPage" data-require="emby-input,emby-button,emby-select,emby-checkbox">
+    <div id="ListenUrlConfigPage" data-role="page" class="page type-interior pluginConfigurationPage" data-require="emby-input,emby-button,emby-select,emby-checkbox">
         <div data-role="content">
             <div class="content-primary">
-                <form id="TemplateConfigForm">
+                <form id="ListenUrlConfigForm">
                     <div class="selectContainer">
                         <label class="selectLabel" for="Options">Several Options</label>
                         <select is="emby-select" id="Options" name="Options" class="emby-select-withcolor emby-select">
@@ -41,14 +41,14 @@
             </div>
         </div>
         <script type="text/javascript">
-            var TemplateConfig = {
-                pluginUniqueId: 'eb5d7894-8eef-4b36-aa6f-5d124e828ce1'
+            var ListenUrlConfig = {
+                pluginUniqueId: 'f7f33b15-a6cf-42a7-813d-169f458cf6e0'
             };
 
-            document.querySelector('#TemplateConfigPage')
+            document.querySelector('#ListenUrlConfigPage')
                 .addEventListener('pageshow', function() {
                     Dashboard.showLoadingMsg();
-                    ApiClient.getPluginConfiguration(TemplateConfig.pluginUniqueId).then(function (config) {
+                    ApiClient.getPluginConfiguration(ListenUrlConfig.pluginUniqueId).then(function (config) {
                         document.querySelector('#Options').value = config.Options;
                         document.querySelector('#AnInteger').value = config.AnInteger;
                         document.querySelector('#TrueFalseSetting').checked = config.TrueFalseSetting;
@@ -57,15 +57,15 @@
                     });
                 });
 
-            document.querySelector('#TemplateConfigForm')
+            document.querySelector('#ListenUrlConfigForm')
                 .addEventListener('submit', function(e) {
                 Dashboard.showLoadingMsg();
-                ApiClient.getPluginConfiguration(TemplateConfig.pluginUniqueId).then(function (config) {
+                ApiClient.getPluginConfiguration(ListenUrlConfig.pluginUniqueId).then(function (config) {
                     config.Options = document.querySelector('#Options').value;
                     config.AnInteger = document.querySelector('#AnInteger').value;
                     config.TrueFalseSetting = document.querySelector('#TrueFalseSetting').checked;
                     config.AString = document.querySelector('#AString').value;
-                    ApiClient.updatePluginConfiguration(TemplateConfig.pluginUniqueId, config).then(function (result) {
+                    ApiClient.updatePluginConfiguration(ListenUrlConfig.pluginUniqueId, config).then(function (result) {
                         Dashboard.processPluginConfigurationUpdateResult(result);
                     });
                 });

--- a/Jellyfin.Plugin.Template/IDownloadUrlBuilder.cs
+++ b/Jellyfin.Plugin.Template/IDownloadUrlBuilder.cs
@@ -1,6 +1,6 @@
 using MediaBrowser.Controller.Entities;
 
-namespace Jellyfin.Plugin.Template;
+namespace Jellyfin.Plugin.ListenUrl;
 
 /// <summary>
 /// Service that builds download URLs for items.

--- a/Jellyfin.Plugin.Template/Jellyfin.Plugin.Template.csproj
+++ b/Jellyfin.Plugin.Template/Jellyfin.Plugin.Template.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RootNamespace>Jellyfin.Plugin.Template</RootNamespace>
+    <RootNamespace>Jellyfin.Plugin.ListenUrl</RootNamespace>
+    <AssemblyName>Jellyfin.Plugin.ListenUrl</AssemblyName>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>

--- a/Jellyfin.Plugin.Template/ListenUrlBuilder.cs
+++ b/Jellyfin.Plugin.Template/ListenUrlBuilder.cs
@@ -2,7 +2,7 @@ using System;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Audio;
 
-namespace Jellyfin.Plugin.Template;
+namespace Jellyfin.Plugin.ListenUrl;
 
 /// <summary>
 /// Implementation of <see cref="IDownloadUrlBuilder"/> that returns a custom

--- a/Jellyfin.Plugin.Template/Plugin.cs
+++ b/Jellyfin.Plugin.Template/Plugin.cs
@@ -1,13 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using Jellyfin.Plugin.Template.Configuration;
+using Jellyfin.Plugin.ListenUrl.Configuration;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Serialization;
 
-namespace Jellyfin.Plugin.Template;
+namespace Jellyfin.Plugin.ListenUrl;
 
 /// <summary>
 /// The main plugin.
@@ -26,10 +26,10 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     }
 
     /// <inheritdoc />
-    public override string Name => "Template";
+    public override string Name => "Listen URL";
 
     /// <inheritdoc />
-    public override Guid Id => Guid.Parse("eb5d7894-8eef-4b36-aa6f-5d124e828ce1");
+    public override Guid Id => Guid.Parse("f7f33b15-a6cf-42a7-813d-169f458cf6e0");
 
     /// <summary>
     /// Gets the current plugin instance.

--- a/Jellyfin.Plugin.Template/ServiceRegistrator.cs
+++ b/Jellyfin.Plugin.Template/ServiceRegistrator.cs
@@ -2,7 +2,7 @@ using MediaBrowser.Controller;
 using MediaBrowser.Controller.Plugins;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Jellyfin.Plugin.Template;
+namespace Jellyfin.Plugin.ListenUrl;
 
 /// <summary>
 /// Registers plugin services with the Jellyfin server.

--- a/build.yaml
+++ b/build.yaml
@@ -1,16 +1,17 @@
 ---
-name: "Template"
-guid: "eb5d7894-8eef-4b36-aa6f-5d124e828ce1"
-version: "1.0.0.0"
+name: "Listen URL"
+guid: "f7f33b15-a6cf-42a7-813d-169f458cf6e0"
+version: "0.1.0.0"
 targetAbi: "10.9.0.0"
 framework: "net8.0"
-overview: "Short description about your plugin"
+overview: "Provide simple /listen URLs for audio streams"
 description: >
-  This is a longer description that can span more than one
-  line and include details about your plugin.
+  Changes the URL copied from the **Copy Stream** button to a
+  short `/listen/<item_id>` format. Requires using a reverse
+  proxy to handle the `/listen` endpoint.
 category: "General"
 owner: "jellyfin"
 artifacts:
-- "Jellyfin.Plugin.Template.dll"
+- "Jellyfin.Plugin.ListenUrl.dll"
 changelog: >
-  changelog
+  Initial release


### PR DESCRIPTION
## Summary
- rename plugin to Listen URL
- update assembly and namespace
- tweak plugin configuration page
- set plugin metadata and version

## Testing
- `dotnet build Jellyfin.Plugin.Template.sln -c Release`
- `dotnet publish Jellyfin.Plugin.Template.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_684a8acf319883208b6ef7810086f73b