### PR TITLE
Fix repo name in workflows

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -15,6 +15,6 @@ jobs:
   call:
     uses: jellyfin/jellyfin-meta-plugins/.github/workflows/changelog.yaml@master
     with:
-      repository-name: jellyfin/jellyfin-plugin-template
+      repository-name: jellyfin/jellyfin-listen-url-plugin
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scan-codeql.yaml
+++ b/.github/workflows/scan-codeql.yaml
@@ -17,4 +17,4 @@ jobs:
   call:
     uses: jellyfin/jellyfin-meta-plugins/.github/workflows/scan-codeql.yaml@master
     with:
-      repository-name: jellyfin/jellyfin-plugin-template
+      repository-name: jellyfin/jellyfin-listen-url-plugin


### PR DESCRIPTION
## Summary
- fix `repository-name` to match the Listen URL plugin

## Testing
- `dotnet test --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_684a93bf343883208b87d96fc8bdeda1